### PR TITLE
Fix testing

### DIFF
--- a/.applier/group_vars/seed-hosts.yml
+++ b/.applier/group_vars/seed-hosts.yml
@@ -1,17 +1,17 @@
 ---
-namespace: jenkins-slaves
+namespace: jenkins-agents
 repository_url: https://github.com/redhat-cop/containers-quickstarts.git
-slave_repo_ref: master
+agent_repo_ref: master
 templates_repo_ref: v1.4.16
 
-jenkins_slaves:
+jenkins_agents:
   build:
     ansible:
       BUILDER_IMAGE_NAME: quay.io/openshift/origin-jenkins-agent-base:4.4
       DOCKERFILE_PATH: Dockerfile
-      NAME: jenkins-slave-ansible
-      SOURCE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-ansible
-      SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      NAME: jenkins-agent-ansible
+      SOURCE_CONTEXT_DIR: jenkins-agents/jenkins-agent-ansible
+      SOURCE_REPOSITORY_REF: "{{ agent_repo_ref }}"
       SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     arachni: {}
     argocd: {}
@@ -34,94 +34,94 @@ jenkins_slaves:
 test_pipelines:
   deploy:
     ansible:
-      NAME: jenkins-slave-ansible
-      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-ansible
+      NAME: jenkins-agent-ansible
+      PIPELINE_CONTEXT_DIR: jenkins-agents/jenkins-agent-ansible
       PIPELINE_FILENAME: Jenkinsfile.test
-      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ agent_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     arachni:
-      NAME: jenkins-slave-arachni
-      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-arachni
+      NAME: jenkins-agent-arachni
+      PIPELINE_CONTEXT_DIR: jenkins-agents/jenkins-agent-arachni
       PIPELINE_FILENAME: Jenkinsfile.test
-      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ agent_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     argocd:
-      NAME: jenkins-slave-argocd
-      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-argocd
+      NAME: jenkins-agent-argocd
+      PIPELINE_CONTEXT_DIR: jenkins-agents/jenkins-agent-argocd
       PIPELINE_FILENAME: Jenkinsfile.test
-      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ agent_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     conftest:
-      NAME: jenkins-slave-conftest
-      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-conftest
+      NAME: jenkins-agent-conftest
+      PIPELINE_CONTEXT_DIR: jenkins-agents/jenkins-agent-conftest
       PIPELINE_FILENAME: Jenkinsfile.test
-      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ agent_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     erlang:
-      NAME: jenkins-slave-erlang
-      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-erlang
+      NAME: jenkins-agent-erlang
+      PIPELINE_CONTEXT_DIR: jenkins-agents/jenkins-agent-erlang
       PIPELINE_FILENAME: Jenkinsfile.test
-      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ agent_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     helm:
-      NAME: jenkins-slave-helm
-      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-helm
+      NAME: jenkins-agent-helm
+      PIPELINE_CONTEXT_DIR: jenkins-agents/jenkins-agent-helm
       PIPELINE_FILENAME: Jenkinsfile.test
-      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ agent_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     golang:
-      NAME: jenkins-slave-golang
-      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-golang
+      NAME: jenkins-agent-golang
+      PIPELINE_CONTEXT_DIR: jenkins-agents/jenkins-agent-golang
       PIPELINE_FILENAME: Jenkinsfile.test
-      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ agent_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     gradle:
-      NAME: jenkins-slave-gradle
-      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-gradle
+      NAME: jenkins-agent-gradle
+      PIPELINE_CONTEXT_DIR: jenkins-agents/jenkins-agent-gradle
       PIPELINE_FILENAME: Jenkinsfile.test
-      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ agent_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     image-mgmt:
-      NAME: jenkins-slave-image-mgmt
-      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-image-mgmt
+      NAME: jenkins-agent-image-mgmt
+      PIPELINE_CONTEXT_DIR: jenkins-agents/jenkins-agent-image-mgmt
       PIPELINE_FILENAME: Jenkinsfile.test
-      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ agent_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     mongodb:
-      NAME: jenkins-slave-mongodb
-      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-mongodb
+      NAME: jenkins-agent-mongodb
+      PIPELINE_CONTEXT_DIR: jenkins-agents/jenkins-agent-mongodb
       PIPELINE_FILENAME: Jenkinsfile.test
-      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ agent_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     mvn:
-      NAME: jenkins-slave-mvn
-      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-mvn
+      NAME: jenkins-agent-mvn
+      PIPELINE_CONTEXT_DIR: jenkins-agents/jenkins-agent-mvn
       PIPELINE_FILENAME: Jenkinsfile.test
-      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ agent_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     npm:
-      NAME: jenkins-slave-npm
-      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-npm
+      NAME: jenkins-agent-npm
+      PIPELINE_CONTEXT_DIR: jenkins-agents/jenkins-agent-npm
       PIPELINE_FILENAME: Jenkinsfile.test
-      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ agent_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     python:
-      NAME: jenkins-slave-python
-      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-python
+      NAME: jenkins-agent-python
+      PIPELINE_CONTEXT_DIR: jenkins-agents/jenkins-agent-python
       PIPELINE_FILENAME: Jenkinsfile.test
-      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ agent_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     ruby:
-      NAME: jenkins-slave-ruby
-      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-ruby
+      NAME: jenkins-agent-ruby
+      PIPELINE_CONTEXT_DIR: jenkins-agents/jenkins-agent-ruby
       PIPELINE_FILENAME: Jenkinsfile.test
-      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ agent_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
     rust:
-      NAME: jenkins-slave-rust
-      PIPELINE_CONTEXT_DIR: jenkins-slaves/jenkins-slave-rust
+      NAME: jenkins-agent-rust
+      PIPELINE_CONTEXT_DIR: jenkins-agents/jenkins-agent-rust
       PIPELINE_FILENAME: Jenkinsfile.test
-      PIPELINE_SOURCE_REPOSITORY_REF: "{{ slave_repo_ref }}"
+      PIPELINE_SOURCE_REPOSITORY_REF: "{{ agent_repo_ref }}"
       PIPELINE_SOURCE_REPOSITORY_URL: "{{ repository_url }}"
 
 openshift_cluster_content:
@@ -143,22 +143,22 @@ openshift_cluster_content:
     namespace: "{{ namespace }}"
     tags:
       - jenkins-ephemeral
-- object: jenkins-slave-nodes
+- object: jenkins-agent-nodes
   content:
-  - name: jenkins-slaves
-    template: "{{ inventory_dir }}/../.openshift/templates/jenkins-slave-generic-template.j2"
-    params_from_vars: "{{ jenkins_slaves.build }}"
+  - name: jenkins-agents
+    template: "{{ inventory_dir }}/../.openshift/templates/jenkins-agent-generic-template.j2"
+    params_from_vars: "{{ jenkins_agents.build }}"
     namespace: "{{ namespace }}"
     tags:
-      - jenkins-slaves
-  - name: jenkins-slave-image-mgmt
-    template: "{{ inventory_dir }}/../.openshift/templates/jenkins-slave-image-mgmt-template.yml"
+      - jenkins-agents
+  - name: jenkins-agent-image-mgmt
+    template: "{{ inventory_dir }}/../.openshift/templates/jenkins-agent-image-mgmt-template.yml"
     namespace: "{{ namespace }}"
     tags:
-      - jenkins-slaves
+      - jenkins-agents
 - object: test-pipelines
   content:
-  - name: Deploy jenkins-slave test pipelines
+  - name: Deploy jenkins-agent test pipelines
     file: "{{ inventory_dir }}/../.openshift/templates/jenkins-pipeline-template-no-ocp-triggers.j2"
     params_from_vars: "{{ test_pipelines.deploy }}"
     namespace: "{{ namespace }}"

--- a/.openshift/templates/jenkins-agent-generic-template.j2
+++ b/.openshift/templates/jenkins-agent-generic-template.j2
@@ -8,35 +8,35 @@ metadata:
     description: "Generic build pod template pre-configured to use a jenkins agent in the
       same project/namespace"
 objects:
-{% if jenkins_slaves is defined %}
-{% for agent, params in jenkins_slaves.build.items() %}
+{% if jenkins_agents is defined %}
+{% for agent, params in jenkins_agents.build.items() %}
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
     labels:
-      build: {{ params.NAME | d('jenkins-slave-' + agent) }}
+      build: {{ params.NAME | d('jenkins-agent-' + agent) }}
       role: jenkins-slave
-    name: {{ params.NAME | d('jenkins-slave-' + agent) }}
+    name: {{ params.NAME | d('jenkins-agent-' + agent) }}
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:
     labels:
-      build: {{ params.NAME | d('jenkins-slave-' + agent) }}
+      build: {{ params.NAME | d('jenkins-agent-' + agent) }}
       type: image
-    name: {{ params.NAME | d('jenkins-slave-' + agent) }}
+    name: {{ params.NAME | d('jenkins-agent-' + agent) }}
   spec:
     nodeSelector:
     output:
       to:
         kind: ImageStreamTag
-        name: {{ params.NAME | d('jenkins-slave-' + agent) }}:{{ params.SLAVE_IMAGE_TAG | d('latest') }}
+        name: {{ params.NAME | d('jenkins-agent-' + agent) }}:{{ params.SLAVE_IMAGE_TAG | d('latest') }}
     postCommit: {}
     resources: {}
     runPolicy: Serial
     source:
-      contextDir: {{ params.SOURCE_CONTEXT_DIR | d('jenkins-slaves/jenkins-slave-' + agent) }}
+      contextDir: {{ params.SOURCE_CONTEXT_DIR | d('jenkins-agents/jenkins-agent-' + agent) }}
       git:
-        ref: {{ params.SOURCE_REPOSITORY_REF | d(slave_repo_ref) | d('master') }}
+        ref: {{ params.SOURCE_REPOSITORY_REF | d(agent_repo_ref) | d('master') }}
         uri: {{ params.SOURCE_REPOSITORY_URL | d(repository_url) | d('https://github.com/redhat-cop/containers-quickstarts') }}
       type: Git
     strategy:

--- a/.openshift/templates/jenkins-agent-image-mgmt-template.yml
+++ b/.openshift/templates/jenkins-agent-image-mgmt-template.yml
@@ -1,13 +1,13 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 labels:
-  template: jenkins-slave-image-mgmt
+  template: jenkins-agent-image-mgmt
 metadata:
   annotations:
-    description: Jenkins Image Management Slave Template.
+    description: Jenkins Image Management Agent Template.
     iconClass: icon-jenkins
-    tags: jenkins,slave
-  name: jenkins-slave-image-mgmt
+    tags: jenkins,agent
+  name: jenkins-agent-image-mgmt
 objects:
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
@@ -19,28 +19,28 @@ objects:
   kind: ImageStream
   metadata:
     labels:
-      build: "${JENKINS_SLAVE_NAME}-skopeo"
-    name: "${JENKINS_SLAVE_NAME}-skopeo"
+      build: "${JENKINS_AGENT_NAME}-skopeo"
+    name: "${JENKINS_AGENT_NAME}-skopeo"
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
     annotations:
-      slave-label: ${JENKINS_SLAVE_NAME}
+      agent-label: ${JENKINS_AGENT_NAME}
     labels:
-      build: ${JENKINS_SLAVE_NAME}
+      build: ${JENKINS_AGENT_NAME}
       role: jenkins-slave
-    name: ${JENKINS_SLAVE_NAME}
+    name: ${JENKINS_AGENT_NAME}
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:
     labels:
-      build: ${JENKINS_SLAVE_NAME}
-    name: "${JENKINS_SLAVE_NAME}-skopeo"
+      build: ${JENKINS_AGENT_NAME}
+    name: "${JENKINS_AGENT_NAME}-skopeo"
   spec:
     output:
       to:
         kind: ImageStreamTag
-        name: "${JENKINS_SLAVE_NAME}-skopeo:${SLAVE_IMAGE_TAG}"
+        name: "${JENKINS_AGENT_NAME}-skopeo:${AGENT_IMAGE_TAG}"
     source:
       git:
         uri: ${SOURCE_REPOSITORY_URL}
@@ -65,12 +65,12 @@ objects:
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:
-    name: ${JENKINS_SLAVE_NAME}
+    name: ${JENKINS_AGENT_NAME}
   spec:
     output:
       to:
         kind: ImageStreamTag
-        name: "${JENKINS_SLAVE_NAME}:${SLAVE_IMAGE_TAG}"
+        name: "${JENKINS_AGENT_NAME}:${AGENT_IMAGE_TAG}"
     source:
       dockerfile: |
         FROM ""
@@ -83,7 +83,7 @@ objects:
       - as: null
         from:
           kind: ImageStreamTag
-          name: "${JENKINS_SLAVE_NAME}-skopeo:latest"
+          name: "${JENKINS_AGENT_NAME}-skopeo:latest"
         paths:
         - destinationDir: "."
           sourcePath: /tmp/skopeo/default-policy.json
@@ -106,18 +106,18 @@ parameters:
 - description: Image tag from which to build this image
   name: BUILDER_IMAGE_TAG
   value: "4.4"
-- description: The name for the Jenkins slave.
-  name: JENKINS_SLAVE_NAME
+- description: The name for the Jenkins agent.
+  name: JENKINS_AGENT_NAME
   required: true
-  value: jenkins-slave-image-mgmt
+  value: jenkins-agent-image-mgmt
 - description: Skopeo builder image
   name: SKOPEO_BUILDER_IMAGE_URI
   value: registry.access.redhat.com/ubi8/go-toolset
 - description: Skopeo builder image tag
   name: SKOPEO_BUILDER_IMAGE_TAG
   value: latest
-- description: This is the image tag used for the Jenkins slave.
-  name: SLAVE_IMAGE_TAG
+- description: This is the image tag used for the Jenkins agent.
+  name: AGENT_IMAGE_TAG
   value: latest
 - description: Git source URI for application
   name: SOURCE_REPOSITORY_URL


### PR DESCRIPTION
#### What is this PR About?
Update testing to support renaming Jenkins agents

#### How do we test this?
```
./_test/setup.sh applier cqci-rename-jenkins pabrahamsson/containers-quickstarts my-389
./_test/setup.sh test cqci-rename-jenkins pabrahamsson/containers-quickstarts my-389
```

Unfortunately we can't rename two instances as the `jenkins-sync-plugin` has these values [hard coded](https://github.com/openshift/jenkins-sync-plugin/blob/master/src/main/java/io/fabric8/jenkins/openshiftsync/PodTemplateUtils.java#L418).
- https://github.com/pabrahamsson/containers-quickstarts/blob/my-389/.openshift/templates/jenkins-agent-generic-template.j2#L18
- https://github.com/pabrahamsson/containers-quickstarts/blob/my-389/.openshift/templates/jenkins-agent-image-mgmt-template.yml#L31

I've tested successfully with these changes in my local environment.